### PR TITLE
Update README for memory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Like the docker-machine's `Makefile`, install the `docker-machine-driver-xhyve` 
 |----------------------------------|--------------------------------|--------|------------------------------------------|----------------------------------------------------------|
 | `--xhyve-boot2docker-url`        | `XHYVE_BOOT2DOCKER_URL`        | string | The URL(Path) of the boot2docker image   | `$HOME/.docker/machine/cache/boot2docker.iso`            |
 | `--xhyve-cpu-count`              | `XHYVE_CPU_COUNT`              | int    | Number of CPUs to use the create the VM  | `1`                                                      |
-| `--xhyve-memory-size`            | `XHYVE_MEMORY_SIZE`            | int    | Size of memory for the guest             | `1024`                                                   |
+| `--xhyve-memory`                 | `XHYVE_MEMORY_SIZE`            | int    | Size of memory for the guest             | `1024`                                                   |
 | `--xhyve-disk-size`              | `XHYVE_DISK_SIZE`              | int    | Size of disk for the guest (MB)          | `20000`                                                  |
 | `--xhyve-boot-cmd`               | `XHYVE_BOOT_CMD`               | string | Booting xhyve iPXE commands              | See [boot2docker/boot2docker/doc/AUTOMATED_SCRIPT.md][1] |
 | `--xhyve-experimental-nfs-share` | `XHYVE_EXPERIMENTAL_NFS_SHARE` | bool   | Enable `NFS` folder share (experimental) | `false`                                                  |


### PR DESCRIPTION
The cli shows the memory flag as --xhyve-memory.

Not sure if this is a docs bug or a bug in the driver since the ENV variable seems to look for XHYVE_MEMORY_SIZE