### PR TITLE
Fixes xhyve stdout and stderr printing

### DIFF
--- a/xhyve.go
+++ b/xhyve.go
@@ -330,10 +330,19 @@ func (d *Driver) Start() error {
 		"-d", //TODO fix daemonize flag
 	)
 	log.Debug(cmd)
+
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &bytes.Buffer{}
+
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
 	go func() {
-		err := cmd.Run()
+		err := cmd.Wait()
 		if err != nil {
-			log.Error(err, cmd.Stdout)
+			log.Error(err, cmd.Stdout, cmd.Stderr)
 		}
 	}()
 


### PR DESCRIPTION
Before only `<nil>` was printed, which didn't really help finding the error.