### PR TITLE
Auto-create missing exports file, line break fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4,7 +4,6 @@
 	"Packages": [
 		"github.com/zchee/docker-machine-driver-xhyve",
 		"github.com/zchee/docker-machine-driver-xhyve/bin",
-		"github.com/zchee/docker-machine-driver-xhyve/version",
 		"github.com/zchee/docker-machine-driver-xhyve/vmnet"
 	],
 	"Deps": [
@@ -67,7 +66,7 @@
 		},
 		{
 			"ImportPath": "github.com/johanneswuerbach/nfsexports",
-			"Rev": "1e8afef6424da9a94852ae9a959168662000bfc5"
+			"Rev": "a9068f3f0daa39616953aec11c3eb1209ebc4086"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/vendor/github.com/johanneswuerbach/nfsexports/.travis.yml
+++ b/vendor/github.com/johanneswuerbach/nfsexports/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.5.1
 
 before_script:
-  - sudo touch /etc/exports
-  - sudo nfsd start
+  - sudo nfsd status
+  - sudo touch /etc/exports # Auto-starts nfsd on OS X
   - sleep 5
   - sudo nfsd status

--- a/vendor/github.com/johanneswuerbach/nfsexports/README.md
+++ b/vendor/github.com/johanneswuerbach/nfsexports/README.md
@@ -6,6 +6,8 @@ Go util to manage NFS exports `/etc/exports`.
 
 * Add and remove exports
 * Verify the added export is valid, before updating
+* Auto-creates missing exports file, which auto starts nfsd on OS X
+* Handles missing line breaks
 
 ```go
 package main


### PR DESCRIPTION
* Auto-creates `/etc/exports`, which auto-starts nfsd on OS X
* Various line break merging fixes