### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/xhyve/version.go
+++ b/xhyve/version.go
@@ -7,7 +7,7 @@ var (
 	ConfigVersion int = 1
 
 	// Version should be updated by hand at each release
-	Version string = "0.2.1"
+	Version string = "0.2.2"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit string = "HEAD"


### PR DESCRIPTION
Bug is still exists, but https://github.com/zchee/docker-machine-driver-xhyve/pull/78 for install use homebrew user.