### PR TITLE
fix check for binary root ownership

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -200,7 +200,7 @@ func (d *Driver) PreCommandCheck() error {
 	}
 
 	// Check of own binary owner and uid
-	if int(bin.Sys().(*syscall.Stat_t).Uid) == 501 {
+	if int(bin.Sys().(*syscall.Stat_t).Uid) != 0 {
 		return fmt.Errorf("%s binary needs root owner and uid. See https://github.com/zchee/docker-machine-driver-xhyve#install", bin.Name())
 	}
 


### PR DESCRIPTION
501 is often, but not always, the uid of the user on OS X. For instance in our corp environment, our uid is the same as our active directory id. This new check should be more reliable, as 0 is always the uid of the root user.