### PR TITLE
Set the NFS export to map all the users on the remote to the current user

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -719,7 +719,12 @@ func (d *Driver) setupVirt9pShare() error {
 
 // Setup NFS share
 func (d *Driver) setupNFSShare() error {
-	nfsConfig := fmt.Sprintf("/Users %s -alldirs -maproot=root", d.IPAddress)
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	nfsConfig := fmt.Sprintf("/Users %s -alldirs -mapall=%s", d.IPAddress, user.Username)
 
 	if _, err := nfsexports.Add("", d.nfsExportIdentifier(), nfsConfig); err != nil {
 		return err


### PR DESCRIPTION
Currently for NFS shares the driver maps the remote `root` user to the local `root` user

This causes issues where all files created by the remote are owned by local root and are unaccessible without modifying permissions.

I have changed the NFS mount to map **all** remote users to the current user, this means that files created by the remote now has the same permissions as the local user.

I think this will fix https://github.com/zchee/docker-machine-driver-xhyve/issues/99

[NFS Reference](http://docstore.mik.ua/orelly/unix3/mac/ch03_10.htm)