### PR TITLE
Multiple NFS shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ $ sudo chmod u+s $GOPATH/bin/docker-machine-driver-xhyve
 | `--xhyve-disk-size`              | `XHYVE_DISK_SIZE`              | int    | Size of disk for the guest (MB)          | `20000`                                                  |
 | `--xhyve-boot-cmd`               | `XHYVE_BOOT_CMD`               | string | Booting xhyve iPXE commands              | See [boot2docker/boot2docker/doc/AUTOMATED_SCRIPT.md][1] |
 | `--xhyve-virtio-9p`              | `XHYVE_VIRTIO_9P`              | bool   | Enable `virtio-9p` folder share          | `false`                                                  |
-| `--xhyve-experimental-nfs-share` | `XHYVE_EXPERIMENTAL_NFS_SHARE` | bool   | Enable `NFS` folder share (experimental) | `false`                                                  |
+| `--xhyve-experimental-nfs-share-enable` | `XHYVE_EXPERIMENTAL_NFS_SHARE_ENABLE` | bool   | Enable `NFS` folder share (experimental) | `false`                                                  |
+| `--xhyve-experimental-nfs-share` | `XHYVE_EXPERIMENTAL_NFS_SHARE` | string   | Path to a host folder to be shared inside the guest |                                                   |
+| `--xhyve-experimental-nfs-share-root` | `XHYVE_EXPERIMENTAL_NFS_SHARE_ROOT` | string   | root path at which the NFS shares will be mounted| `/xhyve-nfsshares`                                                  |
 
 If you want use `virtio-9p` folder sharing, need custom `boot2docker.iso`.  
 See https://github.com/zchee/boot2docker-legacy/releases.

--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -42,7 +42,7 @@ const (
 	defaultISOFilename    = "boot2docker.iso"
 	defaultPrivateKeyPath = ""
 	defaultUUID           = ""
-	defaultNFSShare       = false
+	defaultNFSShareEnable = false
 	rootVolumeName        = "root-volume"
 	defaultDiskNumber     = -1
 	defaultVirtio9p       = false
@@ -60,7 +60,7 @@ type Driver struct {
 	Memory         int
 	PrivateKeyPath string
 	UUID           string
-	NFSShare       bool
+	NFSShareEnable bool
 	DiskNumber     int
 	Virtio9p       bool
 	Virtio9pFolder string
@@ -88,7 +88,7 @@ func NewDriver(hostName, storePath string) *Driver {
 		Memory:         defaultMemory,
 		PrivateKeyPath: defaultPrivateKeyPath,
 		UUID:           defaultUUID,
-		NFSShare:       defaultNFSShare,
+		NFSShareEnable: defaultNFSShareEnable,
 		DiskNumber:     defaultDiskNumber,
 		Virtio9p:       defaultVirtio9p,
 	}
@@ -134,8 +134,8 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Setup virtio-9p folder share",
 		},
 		mcnflag.BoolFlag{
-			EnvVar: "XHYVE_EXPERIMENTAL_NFS_SHARE",
-			Name:   "xhyve-experimental-nfs-share",
+			EnvVar: "XHYVE_EXPERIMENTAL_NFS_SHARE_ENABLE",
+			Name:   "xhyve-experimental-nfs-share-enable",
 			Usage:  "Setup NFS shared folder (requires root)",
 		},
 	}
@@ -186,7 +186,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPort = 22
 	d.Virtio9p = flags.Bool("xhyve-virtio-9p")
 	d.Virtio9pFolder = "/Users"
-	d.NFSShare = flags.Bool("xhyve-experimental-nfs-share")
+	d.NFSShareEnable = flags.Bool("xhyve-experimental-nfs-share-enable")
 
 	return nil
 }
@@ -390,7 +390,7 @@ func (d *Driver) Create() error {
 	}
 
 	// Setup NFS sharing
-	if d.NFSShare {
+	if d.NFSShareEnable {
 		log.Infof("NFS share folder must be root. Please insert root password.")
 		err = d.setupNFSShare()
 		if err != nil {
@@ -487,7 +487,7 @@ func (d *Driver) Remove() error {
 		return err
 	}
 
-	if d.NFSShare {
+	if d.NFSShareEnable {
 		log.Infof("Remove NFS share folder must be root. Please insert root password.")
 		if _, err := nfsexports.Remove("", d.nfsExportIdentifier()); err != nil {
 			log.Errorf("failed removing nfs share: %s", err.Error())

--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -43,6 +44,7 @@ const (
 	defaultPrivateKeyPath = ""
 	defaultUUID           = ""
 	defaultNFSShareEnable = false
+	defaultNFSSharesRoot  = "/xhyve-nfsshares"
 	rootVolumeName        = "root-volume"
 	defaultDiskNumber     = -1
 	defaultVirtio9p       = false
@@ -61,6 +63,8 @@ type Driver struct {
 	PrivateKeyPath string
 	UUID           string
 	NFSShareEnable bool
+	NFSShares      []string
+	NFSSharesRoot  string
 	DiskNumber     int
 	Virtio9p       bool
 	Virtio9pFolder string
@@ -89,6 +93,7 @@ func NewDriver(hostName, storePath string) *Driver {
 		PrivateKeyPath: defaultPrivateKeyPath,
 		UUID:           defaultUUID,
 		NFSShareEnable: defaultNFSShareEnable,
+		NFSSharesRoot:  defaultNFSSharesRoot,
 		DiskNumber:     defaultDiskNumber,
 		Virtio9p:       defaultVirtio9p,
 	}
@@ -137,6 +142,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "XHYVE_EXPERIMENTAL_NFS_SHARE_ENABLE",
 			Name:   "xhyve-experimental-nfs-share-enable",
 			Usage:  "Setup NFS shared folder (requires root)",
+		},
+		mcnflag.StringSliceFlag{
+			EnvVar: "XHYVE_EXPERIMENTAL_NFS_SHARE",
+			Name:   "xhyve-experimental-nfs-share",
+			Usage:  "Setup NFS shared folder (requires root)",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "XHYVE_EXPERIMENTAL_NFS_SHARE_ROOT",
+			Name:   "xhyve-experimental-nfs-share-root",
+			Usage:  "root directory where the NFS shares will be mounted inside the machine",
 		},
 	}
 }
@@ -187,6 +202,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Virtio9p = flags.Bool("xhyve-virtio-9p")
 	d.Virtio9pFolder = "/Users"
 	d.NFSShareEnable = flags.Bool("xhyve-experimental-nfs-share-enable")
+	d.NFSShares = flags.StringSlice("xhyve-experimental-nfs-share")
+	d.NFSSharesRoot = flags.String("xhyve-experimental-nfs-share-root")
 
 	return nil
 }
@@ -489,8 +506,10 @@ func (d *Driver) Remove() error {
 
 	if d.NFSShareEnable {
 		log.Infof("Remove NFS share folder must be root. Please insert root password.")
-		if _, err := nfsexports.Remove("", d.nfsExportIdentifier()); err != nil {
-			log.Errorf("failed removing nfs share: %s", err.Error())
+		for _, share := range d.NFSShares {
+			if _, err := nfsexports.Remove("", d.nfsExportIdentifier(share)); err != nil {
+				log.Errorf("failed removing nfs share (%s): %s", share, err.Error())
+			}
 		}
 
 		if err := nfsexports.ReloadDaemon(); err != nil {
@@ -724,26 +743,38 @@ func (d *Driver) setupNFSShare() error {
 		return err
 	}
 
-	nfsConfig := fmt.Sprintf("/Users %s -alldirs -mapall=%s", d.IPAddress, user.Username)
-
-	if _, err := nfsexports.Add("", d.nfsExportIdentifier(), nfsConfig); err != nil {
-		return err
-	}
-
-	if err := nfsexports.ReloadDaemon(); err != nil {
-		return err
-	}
-
 	hostIP, err := vmnet.GetNetAddr()
 	if err != nil {
 		return err
 	}
 
 	bootScriptName := "/var/lib/boot2docker/bootlocal.sh"
-	bootScript := fmt.Sprintf("#/bin/bash\\n"+
-		"sudo mkdir -p /Users\\n"+
-		"sudo /usr/local/etc/init.d/nfs-client start\\n"+
-		"sudo mount -t nfs -o noacl,async %s:/Users /Users\\n", hostIP)
+	bootScript := fmt.Sprintf("#/bin/bash\\n")
+
+	bootScript += "sudo /usr/local/etc/init.d/nfs-client start\\n"
+
+	for _, share := range d.NFSShares {
+		if !path.IsAbs(share) {
+			share = d.ResolveStorePath(share)
+		}
+		nfsConfig := fmt.Sprintf("%s %s -alldirs -mapall=%s", share, d.IPAddress, user.Username)
+
+		if _, err := nfsexports.Add("", d.nfsExportIdentifier(share), nfsConfig); err != nil {
+			if strings.Contains(err.Error(), "conflicts with existing export") {
+				log.Info("Conflicting NFS Share not setup and ignored:", err)
+				continue
+			}
+			return err
+		}
+
+		root := path.Clean(d.NFSSharesRoot)
+		bootScript += fmt.Sprintf("sudo mkdir -p %s/%s\\n", root, share)
+		bootScript += fmt.Sprintf("sudo mount -t nfs -o noacl,async %s:%s %s/%s\\n", hostIP, share, root, share)
+	}
+
+	if err := nfsexports.ReloadDaemon(); err != nil {
+		return err
+	}
 
 	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee %s && sudo chmod +x %s && %s",
 		bootScript, bootScriptName, bootScriptName, bootScriptName)
@@ -755,8 +786,8 @@ func (d *Driver) setupNFSShare() error {
 	return nil
 }
 
-func (d *Driver) nfsExportIdentifier() string {
-	return fmt.Sprintf("docker-machine-driver-xhyve %s", d.MachineName)
+func (d *Driver) nfsExportIdentifier(path string) string {
+	return fmt.Sprintf("docker-machine-driver-xhyve %s-%s", d.MachineName, path)
 }
 
 func (d *Driver) GetPid() (int, error) {


### PR DESCRIPTION
Added the ability to setup multiple NFS Shares

By default (changeable with `xhyve-experimental-nfs-share-root`, see below) NFS shares are rooted at /xhyve-nfsshares to avoid the situation where a NFS Share `/usr` would be mounted at `/usr`

2 backward incompatible changes:
- renamed `xhyve-experimental-nfs-share` to `xhyve-experimental-nfs-share-enable`
- change `xhyve-experimental-nfs-share` from being a boolean to a string slice taking multiple path to be shared via NFS
- NFS Shares are now mounted under a default directory /xhyve-nfsshares (the old code was mounting everything under `/` causing, for example, `/usr` to be mounted at `/usr`)

Other change:
- add `xhyve-experimental-nfs-share-root` to allow specifying where in the guest the NFS Shares will be rooted at

Here's an example of how to use:

`docker-machine -D create -d xhyve --xhyve-disk-size 40000 --xhyve-memory-size 4000 --xhyve-cpu-count 2 --xhyve-experimental-nfs-share-enable --xhyve-experimental-nfs-share /Users --xhyve-experimental-nfs-share /usr/ --xhyve-experimental-nfs-share-root /nfsharesfromhost test`

This command will share the host folders /Users and /usr in the guest at /nfsharesfromhost/Users and /nfsharesfromhost/usr