### PR TITLE
CI: upgrade TravisCI go version to 1.6.3 and 1.7rc5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ osx_image: xcode7.3
 language: go
 
 go:
-  - 1.5.3
-  - 1.6beta2
+  - 1.6.3
+  - 1.7rc5
   - tip
 
 env:


### PR DESCRIPTION
~~`1.7rc5` is wait for travis-ci/gimme update....~~