### PR TITLE
Auto-detect whether the kernel is bzImage or vmlinuz.

### DIFF
--- a/vmnet/vmnet.go
+++ b/vmnet/vmnet.go
@@ -16,14 +16,8 @@ const (
 	NET_MASK_KEY = "Shared_Net_Mask"
 )
 
-// isExist returns whether the filename is exists.
-func isExist(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
-}
-
 func GetNetAddr() (net.IP, error) {
-	if !isExist(CONFIG_PLIST + ".plist") {
+	if !IsExist(CONFIG_PLIST + ".plist") {
 		return nil, fmt.Errorf("Does not exist %s", CONFIG_PLIST+".plist")
 	}
 
@@ -39,7 +33,7 @@ func GetNetAddr() (net.IP, error) {
 }
 
 func getNetMask() (net.IPMask, error) {
-	if !isExist(CONFIG_PLIST + ".plist") {
+	if !IsExist(CONFIG_PLIST + ".plist") {
 		return nil, fmt.Errorf("Does not exist %s", CONFIG_PLIST+".plist")
 	}
 
@@ -69,4 +63,10 @@ func GetIPNet() (*net.IPNet, error) {
 		IP:   ip.Mask(mask),
 		Mask: mask,
 	}, nil
+}
+
+// IsExist returns whether the filename is exists.
+func IsExist(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
 }


### PR DESCRIPTION
This changes the extract function to just copy everything it can find, and it moves the detection into the getXhyveArgs function.

What do you think of this approach?

Ref #140 
