### PR TITLE
Fix #150 Extract kernel options from the syslinux.conf file if exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ _build/
 # oasis generated files
 setup.data
 setup.log
+
+# Intellij geneatered directory
+.idea


### PR DESCRIPTION
@zchee please do a review. I tested with boot2docker, minikube and centos all works as expected. I am still a golang newbie so code might be not so appealing but happy to improve as per suggestion.

Also tested with ubuntu and get error message as expected.

```
(ubuntu) DBG | Extracting Kernel Options
Error creating machine: Error in driver during machine creation: Not abled to parse isolinux.cfg, Please use --xhyve-boot-cmd option
```