### PR TITLE
Remove unused CaCertPath option

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -40,7 +40,6 @@ const (
 	defaultBoot2DockerURL = ""
 	defaultBootCmd        = ""
 	defaultCPU            = 1
-	defaultCaCertPath     = ""
 	defaultDiskSize       = 20000
 	defaultMacAddr        = ""
 	defaultMemory         = 1024
@@ -59,7 +58,6 @@ type Driver struct {
 	*b2d.B2dUtils
 
 	Boot2DockerURL string
-	CaCertPath     string
 	PrivateKeyPath string
 
 	CPU            int


### PR DESCRIPTION
This isn't used anywhere as far as I can tell.  We don't set it in minikube and its default value is ""