### PR TITLE
Wait for IP before setting up mounts

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -482,9 +482,11 @@ func (d *Driver) Start() error {
 		}
 	}()
 
-	d.setupMounts()
+	if err := d.waitForIP(); err != nil {
+		return err
+	}
 
-	return d.waitForIP()
+	return d.setupMounts()
 }
 
 func (d *Driver) Stop() error {


### PR DESCRIPTION
If we don't wait for the IP before setting up mounts, theres a chance
that the host isn't ready before we try to set up the 9p mount

ref https://github.com/kubernetes/minikube/issues/1133#issuecomment-282078827