### PR TITLE
Don't hardcode the docker user id

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -907,7 +907,7 @@ func (d *Driver) setupVirt9pShare() error {
 	bootScriptName := "/var/lib/boot2docker/bootlocal.sh"
 	bootScript := fmt.Sprintf("#/bin/bash\\n"+
 		"sudo mkdir -p %s\\n"+
-		"sudo mount -t 9p -o version=9p2000 -o trans=virtio -o uname=%s -o dfltuid=1000 -o dfltgid=50 -o access=any host %s", d.Virtio9pFolder, user.Username, d.Virtio9pFolder)
+		"sudo mount -t 9p -o version=9p2000 -o trans=virtio -o uname=%s -o dfltuid=$(id -u docker) -o dfltgid=50 -o access=any host %s", d.Virtio9pFolder, user.Username, d.Virtio9pFolder)
 
 	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee %s && sudo chmod +x %s && %s",
 		bootScript, bootScriptName, bootScriptName, bootScriptName)


### PR DESCRIPTION
The docker user ID is currently hardcoded to 1000, which is causing issues: https://github.com/kubernetes/minikube/issues/1374

I believe this is because there is a race condition in which user is created first (docker or rkt).

We may want to make this take an option for which username (docker or rkt) but I think that it would be expected by most uses for these files to be owned by the docker user, since that is the user they'll be logging in as.

FYI @zchee 