### PR TITLE
Ignore setupmounts

### DIFF
--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -724,7 +724,7 @@ func (d *Driver) generateRawDiskImage(size int64) error {
 	}
 	f.Close()
 
-	if err := os.Truncate(diskPath, d.DiskSize * 1048576); err != nil {
+	if err := os.Truncate(diskPath, d.DiskSize*1048576); err != nil {
 		return err
 	}
 

--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -499,7 +499,11 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	return d.setupMounts()
+	if err := d.setupMounts(); err != nil {
+		log.Warnf("Error setting up mounts: %v", err)
+	}
+
+	return nil
 }
 
 func (d *Driver) Stop() error {


### PR DESCRIPTION
The 9p mount already exists in this case.  This is reverting back to a similar behavior before
https://github.com/zchee/docker-machine-driver-xhyve/pull/161/files

This now logs a warning, but this is a not fatal error on a recreate.  I'm not sure there's
a cleaner way since Start() has no context of if it is called on new VM or a recently stopped VM.

Reference: https://github.com/kubernetes/minikube/issues/1400#issuecomment-298503774