### PR TITLE
ci/travis: fix opam install packages to locked io-page to 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 os: osx
 osx_image: xcode8
 
@@ -14,6 +12,8 @@ env:
     - HOMEBREW_NO_AUTO_UPDATE=1
     - MAKEFLAGS="-j$(sysctl -n hw.ncpu)"
     - RELEASE_GO_VERSION=''
+    - OPAMYES=1
+    - V=1
 
 before_install:
   - uname -a
@@ -21,7 +21,7 @@ before_install:
   # for ocaml-qcow
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/opam.rb
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/libev.rb
-  - opam --version && opam init --yes && opam install --yes uri qcow-format ocamlfind conf-libev
+  - opam --version && opam init && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev
   - eval `opam config env`
 
 install:


### PR DESCRIPTION
~Update opam packages dependency to latest.~
~See also: https://github.com/moby/hyperkit#building~

version locked io-page to 1.6.1.