### PR TITLE
NFS and Virtio9p mounts setup refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Usage
 | `--xhyve-boot-initrd`            | `XHYVE_BOOT_INITRD`            | string | `''`                                                                                                                                 |
 | `--xhyve-qcow2`                  | `XHYVE_QCOW2`                  | bool   | `false`                                                                                                                              |
 | `--xhyve-virtio-9p`              | `XHYVE_VIRTIO_9P`              | bool   | `false`                                                                                                                              |
-| `--xhyve-experimental-nfs-share-enable` | `XHYVE_EXPERIMENTAL_NFS_SHARE_ENABLE` | bool   | Enable `NFS` folder share (experimental) | `false`                                                  |
 | `--xhyve-experimental-nfs-share` | `XHYVE_EXPERIMENTAL_NFS_SHARE` | string   | Path to a host folder to be shared inside the guest |                                                   |
 | `--xhyve-experimental-nfs-share-root` | `XHYVE_EXPERIMENTAL_NFS_SHARE_ROOT` | string   | root path at which the NFS shares will be mounted| `/xhyve-nfsshares`                                                  |
 
@@ -176,9 +175,18 @@ This may be significantly faster for I/O intensive applications, at the potentia
 Enable `virtio-9p` folder share.  
 If you using docker-machine, `CONFIG_NET_9P=y` support is included in boot2docker as of version v1.10.2.
 
-#### `--xhyve-experimental-nfs-share`
+#### `--xhyve-experimental-nfs-share /path/to/host/folder`
 
-Enable `NFS` folder sharing.
+Share `path/to/host/folder` inside the guest at the path specified by `--xhyve-experimental-nfs-share-root` (which itself defaults to `/xhyve-nfsshares`).
+
+Can be specified multiple times
+
+#### `--xhyve-experimental-nfs-share-root /path`
+
+By default, NFS Shares will be mounted in the Guest at `/xhyve-nfsshares`.
+
+You can change this default by specifying `--xhyve-experimental-nfs-share-root /path`, `/path` being a path to the root
+
 
 Known isuue
 -----------

--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -484,7 +484,9 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	d.setupMounts()
+	if err := d.setupMounts(); err != nil {
+		return fmt.Errorf("Error setting up mounts: %v", err)
+	}
 
 	return nil
 }
@@ -533,10 +535,6 @@ func (d *Driver) Start() error {
 
 	if err := d.waitForIP(); err != nil {
 		return err
-	}
-
-	if err := d.setupMounts(); err != nil {
-		log.Warnf("Error setting up mounts: %v", err)
 	}
 
 	return nil
@@ -1006,8 +1004,8 @@ func (d *Driver) setupVirt9pShare() error {
 		i++
 	}
 
-	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee %s && sudo chmod +x %s && %s",
-		bootScript, bootScriptName, bootScriptName, bootScriptName)
+	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee -a %s && sudo chmod +x %s",
+		bootScript, bootScriptName, bootScriptName)
 
 	if _, err := drivers.RunSSHCommandFromDriver(d, writeScriptCmd); err != nil {
 		return err
@@ -1056,8 +1054,8 @@ func (d *Driver) setupNFSShare() error {
 		return err
 	}
 
-	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee %s && sudo chmod +x %s && %s",
-		bootScript, bootScriptName, bootScriptName, bootScriptName)
+	writeScriptCmd := fmt.Sprintf("echo -e \"%s\" | sudo tee -a %s && sudo chmod +x %s",
+		bootScript, bootScriptName, bootScriptName)
 
 	if _, err := drivers.RunSSHCommandFromDriver(d, writeScriptCmd); err != nil {
 		return err


### PR DESCRIPTION
I have been working those past few days on `xhyve`'s ability to mount **multiple** folders from the Host to the Guest, either via **NFS** or via **Virtio9p**.

At this point, the NFS work has already been merged into master: https://github.com/zchee/docker-machine-driver-xhyve/pull/121

Since this last PR (#121), I have been working on allowing multiple mount point using Virtio9p, and have submitted a PR currently waiting for approval: https://github.com/zchee/docker-machine-driver-xhyve/pull/194. Until that point, `xhyve`'s was "hardcodingly" mounting the Host `/Users` folder into the Guest via Virtio9p, and the user had no choice in the matter.

At the same time, I have been working on modifying `minikube` (https://github.com/kubernetes/minikube) to allow `minikube` users to create `minikube` machines with multiple mounts (either NFS or Virtio9p). 

However, while working on `minikube` I ran into issues that ultimately were caused by `xhyve`'s use of the `bootlocal.sh` script for setting up NFS and Virtio9p mount points: when I would create a new minikube machine, my mount points would not show up at creation time. They would only show up after a `minikube stop` followed by a `minikube start`. 

After debugging I realized that the `bootlocal.sh` script wasn't being executed when the `minikube` machine was created the very first time. After looking around, I found this [boot2docker FAQ](https://github.com/boot2docker/boot2docker/blob/master/doc/FAQ.md#local-customisation-with-persistent-partition) explaining the role of the `bootlocal.sh` script, which made me realize that `xhyve`'s use of this script was 1- not proper, 2- superfluous.

This Pull Request addresses this issue and will also allow me to submit a PR to the `minikube` project allowing `minikube` users to make use of multiple, user-defined, NFS and/or Virtio9p shared folders.