### PR TITLE
Update 'xcrun clang' usage for XCode 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ MAIN_FILE := $(shell grep "func main\(\)" *.go -l)
 # ----------------------------------------------------------------------------
 # Define main commands
 
-CC := $(shell xcrun -f clang)
-LIBTOOL := $(shell xcrun -f libtool)
+CC := xcrun --sdk macosx clang
+LIBTOOL := xcrun --sdk macosx libtool
 GO_CMD := $(shell which go)
 GIT_CMD := $(shell which git)
 DOCKER_CMD := $(shell which docker)


### PR DESCRIPTION
In Mojave / XCode 10 environment, C-based dependencies fail to build due to strictness of 'clang' (can't find 'stdlib.h'). The 'xcrun -f clang' does not search OS X include directories by default like the '/usr/bin/clang' does. The solution is to add the '--sdk macosx' to the 'xcrun' call. Also my change calls 'xcrun' every time to run clang—the executable lookup is cached by 'xcrun' so this is not slow.