### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   # for ocaml-qcow
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/opam.rb
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/libev.rb
-  - opam --version && opam init && eval $(opam env) && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev
+  - opam --version && opam init && opam install uri qcow-format io-page ocamlfind conf-libev
   - eval `opam config env`
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   # for ocaml-qcow
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/opam.rb
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/libev.rb
+  - eval $(opam env)
   - opam --version && opam init && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev
   - eval `opam config env`
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
   # for ocaml-qcow
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/opam.rb
   - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/libev.rb
-  - eval $(opam env)
-  - opam --version && opam init && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev
+  - opam --version && opam init && eval $(opam env) && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev
   - eval `opam config env`
 
 install:

--- a/xhyve/xhyve.go
+++ b/xhyve/xhyve.go
@@ -1044,7 +1044,7 @@ func (d *Driver) setupNFSShare() error {
 
 		root := path.Clean(d.NFSSharesRoot)
 		mountCommands += fmt.Sprintf("sudo mkdir -p %s/%s\\n", root, share)
-		mountCommands += fmt.Sprintf("sudo mount -t nfs -o noacl,async %s:%s %s/%s\\n", hostIP, share, root, share)
+		mountCommands += fmt.Sprintf("sudo mount -t nfs -o noacl,async,nfsvers=3 %s:%s %s/%s\\n", hostIP, share, root, share)
 	}
 
 	if err := nfsexports.ReloadDaemon(); err != nil {


### PR DESCRIPTION
Travis seems to be failing

```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
∗ installed ocaml-base-compiler.4.07.1
∗ installed ocaml-config.1
∗ installed ocaml.4.07.1
Done.
# Run eval $(opam env) to update the current shell environment
The following dependencies couldn't be met:
  - io-page → ocaml < 4.06.0
      base of this switch (use `--unlock-base' to force)
No solution found, exiting
The command "opam --version && opam init && opam install uri qcow-format io-page.1.6.1 ocamlfind conf-libev" failed and exited with 20 during .
```